### PR TITLE
1.0.0beta-12 | Deprecate `create` and the `/setup` module route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0beta-12] - 2015-02-16
+
+This version, compared to the previous one only adds deprecation notices that can be fixed by slight modifications. Underlying implementations are not changed.
+
+### Changed
+
+- `create` (both as a named export and the default export) is marked as deprecated, and it has been renamed to `atom`. It will be removed in the further versions, and making the following change is recommended:
+> Before:
+> ```js
+> import create from 'xoid'
+>// or
+> import { create } from 'xoid'
+> ```
+> After:
+> ```js
+> import { atom } from 'xoid'
+> ```
+
+- `inject` and `effect` exports are now exported from the root. They used to be exported from the `xoid/setup` route.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+- `create` (both as a named export and the default export) is removed. Instead use `atom`.
+
+
 ## [1.0.0beta-12] - 2015-02-16
 
 This version, compared to the previous one only adds deprecation notices that can be fixed by slight modifications. Underlying implementations are not changed.
 
-### Changed
+### Deprecated
 
-- `create` (both as a named export and the default export) is marked as deprecated, and it has been renamed to `atom`. It will be removed in the further versions, and making the following change is recommended:
+- `create` (both as a named export and the default export) is marked as deprecated, and it has been renamed to `atom`.
 > Before:
 > ```js
 > import create from 'xoid'
@@ -22,5 +28,12 @@ This version, compared to the previous one only adds deprecation notices that ca
 > ```js
 > import { atom } from 'xoid'
 > ```
-
 - `inject` and `effect` exports are now exported from the root. They used to be exported from the `xoid/setup` route.
+> Before:
+> ```js
+> import { effect, inject } from 'xoid/setup'
+> ```
+> After:
+> ```js
+> import { effect, inject } from 'xoid'
+> ```

--- a/README.md
+++ b/README.md
@@ -100,35 +100,34 @@ Visit <a href="https://xoid.dev">xoid.dev</a> for detailed docs and recipes.
 Atoms are holders of state.
 
 ```js
-import create from 'xoid'
-// or: import { create } from 'xoid'
+import { atom } from 'xoid'
 
-const $count = create(3)
+const $count = atom(3)
 console.log($count.value) // 3
 $count.set(5)
 $count.update((state) => state + 1)
 console.log($count.value) // 6
 ```
 
-Atoms may have actions.
+Atoms can have actions.
 
 ```js
 import create from 'xoid'
 
-const $count = create(5, (atom) => ({
-  increment: () => atom.update(s => s + 1),
-  decrement: () => atom.value-- // `.value` setter is also supported
+const $count = create(5, (a) => ({
+  increment: () => a.update(s => s + 1),
+  decrement: () => a.value-- // `.value` setter is supported too
 }))
 
 $count.actions.increment()
 ```
 
-Perhaps, the best feature of **xoid** is the `.focus` method, which can be used as a selector/lens. **xoid** is based on immutable updates, so if you "surgically" set state of a focused branch, changes will propagate to the root.
+There's the `.focus` method, which can be used as a selector/lens. **xoid** is based on immutable updates, so if you "surgically" set state of a focused branch, changes will propagate to the root.
 
 ```js
 import create from 'xoid'
 
-const $atom = create({ deeply: { nested: { alpha: 5 } } })
+const $atom = atom({ deeply: { nested: { alpha: 5 } } })
 const previousValue = $atom.value
 
 // select `.deeply.nested.alpha`
@@ -146,16 +145,16 @@ assert($atom.value.deeply.nested.alpha === 6) // ✅
 State can be derived from other atoms. This API was heavily inspired by **Recoil**.
 
 ```js
-const $alpha = create(3)
-const $beta = create(5)
+const $alpha = atom(3)
+const $beta = atom(5)
 // derived atom
-const $sum = create((read) => read($alpha) + read($beta))
+const $sum = atom((read) => read($alpha) + read($beta))
 ```
 
 Alternatively, `.map` method can be used to quickly derive the state from a single atom.
 
 ```js
-const $alpha = create(3)
+const $alpha = atom(3)
 // derived atom
 const $doubleAlpha = $alpha.map((s) => s * 2)
 ```
@@ -173,7 +172,7 @@ const unsub = $atom.subscribe((state, previousState) => {
 // later
 unsub()
 ```
-> All methods of a **xoid** atom are covered up to this point. This concludes the basic usage! 🎉
+> This concludes the basic usage! 🎉
 
 ## Framework Integrations
 

--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ console.log($count.value) // 6
 Atoms can have actions.
 
 ```js
-import create from 'xoid'
+import { atom } from 'xoid'
 
-const $count = create(5, (a) => ({
+const $count = atom(5, (a) => ({
   increment: () => a.update(s => s + 1),
   decrement: () => a.value-- // `.value` setter is supported too
 }))
@@ -225,14 +225,14 @@ This might be the most unique feature of **xoid**. With **xoid**, you can write 
 The following is called a "setup" function:
 
 ```js
-import create, { Atom } from 'xoid'
+import { atom, Atom } from 'xoid'
 import { effect, inject } from 'xoid'
 import { ThemeSymbol } from './theme'
 
 export const CounterSetup = ($props: Atom<{ initialValue: number }>) => {
   const { initialValue } = $props.value
 
-  const $counter = create(initialValue)
+  const $counter = atom(initialValue)
   const increment = () => $counter.update((s) => s + 1)
   const decrement = () => $counter.update((s) => s - 1)
 
@@ -271,10 +271,10 @@ import devtools from '@xoid/devtools'
 import create from 'xoid'
 devtools() // run once
 
-const atom = create(
+const $atom = atom(
   { alpha: 5 }, 
-  (atom) => {
-    const $alpha = atom.focus(s => s.alpha)
+  ($atom) => {
+    const $alpha = $atom.focus(s => s.alpha)
     return {
       inc: () => $alpha.update(s => s + 1),
       deeply: { nested: { action: () => $alpha.update((s) => s + 1) } }
@@ -295,14 +295,13 @@ atom.focus(s => s.alpha).set(25)  // "(myAtom) Update ([timestamp])
 No additional syntax is required for state machines. Just use the `create` function.
 
 ```js
-import create from 'xoid'
+import { atom } from 'xoid'
 import { useAtom } from '@xoid/react'
 
 const createMachine = () => {
   const red = { color: '#f00', onClick: () => atom.set(green) }
   const green = { color: '#0f0', onClick: () => atom.set(red) }
-  const atom = create(red)
-  return atom
+  return atom(red)
 }
 
 // in a React component

--- a/README.md
+++ b/README.md
@@ -225,8 +225,7 @@ This might be the most unique feature of **xoid**. With **xoid**, you can write 
 The following is called a "setup" function:
 
 ```js
-import { atom, Atom } from 'xoid'
-import { effect, inject } from 'xoid'
+import { atom, Atom, effect, inject } from 'xoid'
 import { ThemeSymbol } from './theme'
 
 export const CounterSetup = ($props: Atom<{ initialValue: number }>) => {

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ The following is called a "setup" function:
 
 ```js
 import create, { Atom } from 'xoid'
-import { effect, inject } from 'xoid/setup'
+import { effect, inject } from 'xoid'
 import { ThemeSymbol } from './theme'
 
 export const CounterSetup = ($props: Atom<{ initialValue: number }>) => {

--- a/docs/advanced-concepts.md
+++ b/docs/advanced-concepts.md
@@ -5,12 +5,12 @@ title: Advanced concepts
 
 ## Deriving state from external sources
 
-With an additional overload of the `read` function, you can consume external (non-**xoid**) sources. This can be a Redux store, an RxJS observable, or anything that implements getState & subscribe pair. Here is an atom that derives its state from a Redux store:
+With an additional overload of the `get` function, you can consume external (non-**xoid**) sources. This can be a Redux store, an RxJS observable, or anything that implements getState & subscribe pair. Here is an atom that derives its state from a Redux store:
 
 ```js
 import store from './reduxStore'
 
-const derivedAtom = create((read) => read(store.getState, store.subscribe))
+const $derivedAtom = atom((get) => get(store.getState, store.subscribe))
 ```
 As long as the external source implements a getState & subscribe, pair, it can be consumed by **xoid**.
 
@@ -22,7 +22,7 @@ This naming is inspired by Redux's concept of enhancers. For a real-life scenari
 ```js
 import store from './reduxStore'
 
-const $mediator = create((read) => read(store.getState, store.subscribe))
+const $mediator = atom((get) => get(store.getState, store.subscribe))
 
 // we swap the default`.set` method
 $mediator.set = (value: number) => store.dispatch({ type: 'ACTION', payload: value })

--- a/docs/framework-integrations/indtroduction.md
+++ b/docs/framework-integrations/indtroduction.md
@@ -57,7 +57,7 @@ import { ThemeSymbol } from './theme'
 export const CounterSetup = ($props: Atom<{ initialValue: number }>) => {
   const { initialValue } = $props.value
 
-  const $counter = create(initialValue)
+  const $counter = atom(initialValue)
   const increment = () => $counter.update((s) => s + 1)
   const decrement = () => $counter.update((s) => s - 1)
 

--- a/docs/framework-integrations/indtroduction.md
+++ b/docs/framework-integrations/indtroduction.md
@@ -52,7 +52,7 @@ The following is called a "setup" function:
 
 ```js
 import create, { Atom } from 'xoid'
-import { effect, inject } from 'xoid/setup'
+import { effect, inject } from 'xoid'
 import { ThemeSymbol } from './theme'
 
 export const CounterSetup = ($props: Atom<{ initialValue: number }>) => {

--- a/docs/framework-integrations/indtroduction.md
+++ b/docs/framework-integrations/indtroduction.md
@@ -51,8 +51,7 @@ This might be the most unique feature of **xoid**. With **xoid**, you can write 
 The following is called a "setup" function:
 
 ```js
-import create, { Atom } from 'xoid'
-import { effect, inject } from 'xoid'
+import { atom, Atom, effect, inject } from 'xoid'
 import { ThemeSymbol } from './theme'
 
 export const CounterSetup = ($props: Atom<{ initialValue: number }>) => {
@@ -82,7 +81,7 @@ With this feature, you can effectively replace the following framework-specific 
 
 |  | <img src="https://raw.githubusercontent.com/xoidlabs/xoid/master/assets/logo-plain.svg" width="16"/> xoid | <img src="https://raw.githubusercontent.com/xoidlabs/xoid/master/assets/integrations/react.ico" width="16"/> React | <img src="https://raw.githubusercontent.com/xoidlabs/xoid/master/assets/integrations/vue.png" width="16"/> Vue | <img src="https://raw.githubusercontent.com/xoidlabs/xoid/master/assets/integrations/svelte.png" width="16"/> Svelte |
 |---|---|---|---|---|
-| State | `create` | `useState` / `useReducer` | `reactive` / `ref` | `readable` / `writable` |
-| Derived state | `create` | `useMemo` | `computed` | `derived` |
+| State | `atom` | `useState` / `useReducer` | `reactive` / `ref` | `readable` / `writable` |
+| Derived state | `atom` | `useMemo` | `computed` | `derived` |
 | Lifecycle | `effect` | `useEffect` | `onMounted`, `onUnmounted` | `onMount`, `onDestroy` |
 | Dependency injection | `inject` | `useContext` | `inject` | `getContext` |

--- a/docs/framework-integrations/use-atom.md
+++ b/docs/framework-integrations/use-atom.md
@@ -13,11 +13,11 @@ title: useAtom
 Used for subscribing a component to an atom. 
 
 ```js
-import { create } from 'xoid';
+import { atom } from 'xoid';
 import { useAtom } from '@xoid/react'; // or '@xoid/vue' or '@xoid/svelte'
 
-const $number = create(5);
-const $person = create({ name: 'John', surname: 'Doe' });
+const $number = atom(5);
+const $person = atom({ name: 'John', surname: 'Doe' });
 
 // inside a component
 const number = useAtom($number);

--- a/docs/framework-integrations/use-setup.md
+++ b/docs/framework-integrations/use-setup.md
@@ -44,7 +44,7 @@ Vue, Svelte, and more other frameworks on the other hand, use a real closure ins
 
 ```js
 import { useSetup } from '@xoid/react'
-import { effect } from 'xoid/setup'
+import { effect } from 'xoid'
 
 const App = (props: Props) => {
   useSetup(() => {
@@ -67,7 +67,7 @@ const App = (props: Props) => {
 You can call `effect` multiple times, or conditionally. It'll connect to the same `useEffect` call. 
 ```js
 import { useSetup } from '@xoid/react'
-import { effect } from 'xoid/setup'
+import { effect } from 'xoid'
 
 const App = (props: Props) => {
   useSetup(() => {
@@ -91,7 +91,7 @@ Same applies for `inject`.
 
 ```js
 import { useSetup } from '@xoid/react'
-import { inject } from 'xoid/setup'
+import { inject } from 'xoid'
 import { ThemeSymbol } from './some-module'
 
 const App = (props: Props) => {

--- a/docs/framework-integrations/use-setup.md
+++ b/docs/framework-integrations/use-setup.md
@@ -12,11 +12,11 @@ title: useSetup
 ## Basic usage
 
 ```js
-import { create } from 'xoid'
+import { atom } from 'xoid'
 import { useSetup } from '@xoid/react'
 
 // inside a component
-const $num = useSetup(() => create(5))
+const $num = useSetup(() => atom(5))
 ```
 When a second argument is provided, it'll be available in the callback argument **as a reactive atom**.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -38,7 +38,7 @@ yarn add xoid
   <TabItem value="deno">
 
 ```js
-import { create } from 'https://unpkg.com/xoid/index.js'
+import { atom } from 'https://unpkg.com/xoid/index.js'
 ```
 
   </TabItem>

--- a/docs/performance-optimizations.md
+++ b/docs/performance-optimizations.md
@@ -8,7 +8,7 @@ title: Performance optimizations
 Atoms are lazily evaluated. If an atom is created using a *state initializer function*, this function won't run until the `.value` getter is read, or the atom is subscribed for the first time.
 
 ```js
-const $atom = create(() => {
+const $atom = atom(() => {
   console.log('I am lazily evaluated!')
   return expensiveComputation(25)
 })
@@ -28,10 +28,10 @@ You can make use of this feature to avoid expensive computations where possible.
 A derived atom is not much different than a classical atom. Still, its state initializer function will wait for the atom's value to be requested in order to run. 
 
 ```js
-const $alpha = create(3)
-const $beta = create(5)
+const $alpha = atom(3)
+const $beta = atom(5)
 
-const $sum = create((read) => {
+const $sum = atom((read) => {
   console.log('Evaluation occured')
   return read($alpha) + read($beta)
 })
@@ -76,7 +76,7 @@ Observe that `$sum` knew that it needs to rerun its state initializer when it's 
 Same kind of performance optimizations apply to the atoms that are created using the `.map` method.
 
 ```js
-const $count = create(() => {
+const $count = atom(() => {
   console.log('Ancestor atom evaluated')
   return 100
 })

--- a/docs/quick-tutorial.md
+++ b/docs/quick-tutorial.md
@@ -10,23 +10,23 @@ title: Quick Tutorial
 Atoms are holders of state.
 
 ```js
-import create from 'xoid' // or: import { create } from 'xoid'
+import { atom } from 'xoid'
 
-const $count = create(3)
+const $count = atom(3)
 console.log($count.value) // 3
 $count.set(5)
 $count.update((state) => state + 1)
 console.log($count.value) // 6
 ```
 
-Atoms may have actions.
+Atoms can have actions.
 
 ```js
 import create from 'xoid'
 
-const $count = create(5, (atom) => ({
-  increment: () => atom.update(s => s + 1),
-  decrement: () => atom.value-- // `.value` setter is supported too
+const $count = create(5, (a) => ({
+  increment: () => a.update(s => s + 1),
+  decrement: () => a.value-- // `.value` setter is supported too
 }))
 
 $count.actions.increment()
@@ -37,7 +37,7 @@ There's the `.focus` method, which can be used as a selector/lens. **xoid** is b
 ```js
 import create from 'xoid'
 
-const $atom = create({ deeply: { nested: { alpha: 5 } } })
+const $atom = atom({ deeply: { nested: { alpha: 5 } } })
 const previousValue = $atom.value
 
 // select `.deeply.nested.alpha`
@@ -55,16 +55,16 @@ assert($atom.value.deeply.nested.alpha === 6) // ✅
 State can be derived from other atoms. This API was heavily inspired by **Recoil**.
 
 ```js
-const $alpha = create(3)
-const $beta = create(5)
+const $alpha = atom(3)
+const $beta = atom(5)
 // derived atom
-const $sum = create((read) => read($alpha) + read($beta))
+const $sum = atom((read) => read($alpha) + read($beta))
 ```
 
 Alternatively, `.map` method can be used to quickly derive the state from a single atom.
 
 ```js
-const $alpha = create(3)
+const $alpha = atom(3)
 // derived atom
 const $doubleAlpha = $alpha.map((s) => s * 2)
 ```
@@ -82,4 +82,4 @@ const unsub = $atom.subscribe((state, previousState) => {
 // later
 unsub()
 ```
-> All methods of a **xoid** atom are covered up to this point. This concludes the basic usage! 🎉
+> This concludes the basic usage! 🎉

--- a/docs/quick-tutorial.md
+++ b/docs/quick-tutorial.md
@@ -22,9 +22,9 @@ console.log($count.value) // 6
 Atoms can have actions.
 
 ```js
-import create from 'xoid'
+import { atom } from 'xoid'
 
-const $count = create(5, (a) => ({
+const $count = atom(5, (a) => ({
   increment: () => a.update(s => s + 1),
   decrement: () => a.value-- // `.value` setter is supported too
 }))

--- a/docs/recipes-react/creating-react-custom-hooks.md
+++ b/docs/recipes-react/creating-react-custom-hooks.md
@@ -5,9 +5,9 @@ title: Creating React custom hooks
 
 ```js
 const CounterModel = (value: number) =>
-  create(value, (atom) => ({
-    increment: () => atom.update((s) => s + 1),
-    decrement: () => atom.update((s) => s - 1),
+  create(value, (a) => ({
+    increment: () => a.update((s) => s + 1),
+    decrement: () => a.update((s) => s - 1),
   }))
 
 const useCounter = (value: number) => useAtom(() => CounterModel(value), true)

--- a/docs/recipes-react/creating-react-custom-hooks.md
+++ b/docs/recipes-react/creating-react-custom-hooks.md
@@ -5,7 +5,7 @@ title: Creating React custom hooks
 
 ```js
 const CounterModel = (value: number) =>
-  create(value, (a) => ({
+  atom(value, (a) => ({
     increment: () => a.update((s) => s + 1),
     decrement: () => a.update((s) => s - 1),
   }))

--- a/docs/recipes-react/grabbing-refs.md
+++ b/docs/recipes-react/grabbing-refs.md
@@ -6,7 +6,7 @@ title: Grabbing refs
 A **xoid** atom can be used to grab element refs (as in React's terminology) in a typesafe manner. 
 
 ```js
-const $ref = create<HTMLElement>() // Stream<HTMLElement>
+const $ref = atom<HTMLElement>() // Stream<HTMLElement>
 
 $ref.set(document.body)
 ```
@@ -14,11 +14,11 @@ $ref.set(document.body)
 It's completely safe to feed `atom.set` calls as refs to React components as `ref` prop.
 
 ```js
-import create from 'xoid'
+import { atom } from 'xoid'
 import { useSetup } from '@xoid/react'
 // inside React
 const { $ref } = useSetup(() => {
-  const $ref = create<HTMLDivElement>()
+  const $ref = atom<HTMLDivElement>()
   $ref.subscribe((element) => console.log(element))
   return { $ref }
 })

--- a/docs/recipes-react/refactoring-react-classes.md
+++ b/docs/recipes-react/refactoring-react-classes.md
@@ -24,7 +24,7 @@ class App extends React.Component {
 Here's a basic React-like class component runtime prepared with **xoid**.
 
 ```js
-import { create, Atom } from 'xoid'
+import { atom, Atom } from 'xoid'
 
 class Runtime<Props, State> {
   $props: Atom<Props>;
@@ -46,7 +46,7 @@ class Runtime<Props, State> {
 We can then easily evolve into the following, working structure without too much refactor:
 ```js
 class AppRuntime extends Runtime<{}, { alpha: number }> {
-  $state = create({ alpha: 5 });
+  $state = atom({ alpha: 5 });
   incrementAlpha = () => {
     this.setState({ alpha: this.state.alpha + 1 });
   };
@@ -64,7 +64,7 @@ Observe that the only big differece is replacing `this` in the render function w
 After getting rid of `this.setState` usages, we can get rid of the `Runtime` class too.
 ```js
 const AppSetup = ($props: Atom<Props>) => {
-  const $state = create({ alpha: 5 })
+  const $state = atom({ alpha: 5 })
   const incrementAlpha = () => $state.focus('alpha').update((s) => s + 1)
   return { $state, incrementAlpha }
 }

--- a/docs/recipes-react/using-context-correctly.md
+++ b/docs/recipes-react/using-context-correctly.md
@@ -14,13 +14,13 @@ There's [an article by Michel Weststrate](https://medium.com/@mweststrate/how-to
 Let our state to be shared via context be `{alpha: number, beta: number}`. Instead of feeding it directly as a context value, we can wrap it inside an atom. We can create that atom only once, inside a `useSetup` hook.
 
 ```js title="./App.tsx"
-import { create } from 'xoid'
+import { atom } from 'xoid'
 import { useSetup } from '@xoid/react'
 import { MyContext } from './MyContext'
 import { ConsumerComponent } from './ConsumerComponent'
 
 export const App = () => {
-  const contextValue = useSetup(() => create({ alpha: 3, beta: 5 }))
+  const contextValue = useSetup(() => atom({ alpha: 3, beta: 5 }))
 
   return (
     <MyContext.Provider value={contextValue}>
@@ -29,7 +29,7 @@ export const App = () => {
   )
 }
 ```
-> useSetup's callback function will run exactly once, and the context's value reference will remain static, however the atom's internal state is dynamic.
+> useSetup's callback function will run exactly once, and the context's value reference will remain static, however an atom's internal state is dynamic.
 
 ```js title="./MyComponent.tsx"
 import { useContext } from 'react'
@@ -38,13 +38,13 @@ import { useAtom } from '@xoid/react'
 import { MyContext } from './MyContext'
 
 export const MyComponent = () => {
-  const atom = useContext(MyContext)
-  const { alpha, beta } = useAtom(atom)
+  const a = useContext(MyContext)
+  const { alpha, beta } = useAtom(a)
 
   return (
     <div>
       alpha: {state.alpha}, beta: {state.beta}
-      <button onClick={() => atom.focus('alpha').update(s => s + 1)}>increment alpha</button>
+      <button onClick={() => a.focus('alpha').update(s => s + 1)}>increment alpha</button>
     </div>
   )
 }

--- a/docs/recipes-react/using-context-correctly.md
+++ b/docs/recipes-react/using-context-correctly.md
@@ -38,8 +38,8 @@ import { useAtom } from '@xoid/react'
 import { MyContext } from './MyContext'
 
 export const MyComponent = () => {
-  const a = useContext(MyContext)
-  const { alpha, beta } = useAtom(a)
+  const $atom = useContext(MyContext)
+  const { alpha, beta } = useAtom($atom)
 
   return (
     <div>
@@ -50,4 +50,4 @@ export const MyComponent = () => {
 }
 ```
 
-Only the components that subscribe to the content of `MyContext` explicitly via `useAtom` will rerender. Also note that, any component now has the chance to subscribe to a subtree/leaf of the same context such that: `useAtom(atom.focus('alpha'))`. Context selectors are achieved in a single, expressive API! Voilà!
+Only the components that subscribe to the content of `MyContext` explicitly via `useAtom` will rerender. Also note that, any component now has the chance to subscribe to a subtree/leaf of the same context such that: `useAtom($atom.focus('alpha'))`. Context selectors are achieved in a single, expressive API! Voilà!

--- a/docs/recipes/finite-state-machines.md
+++ b/docs/recipes/finite-state-machines.md
@@ -31,7 +31,7 @@ const createMachine = () => {
   const liquid = { name: "water", actions: { freeze, vaporize } };
   const gas = { name: "vapor", actions: { condense } };
 
-  const machine = create(solid)
+  const machine = atom(solid)
   return machine;
 }
 

--- a/docs/recipes/persist-localstorage.md
+++ b/docs/recipes/persist-localstorage.md
@@ -13,6 +13,6 @@ const setLocalStorage = (key) => (state) =>
   localStorage.setItem(key, JSON.stringify(state))
 
 // usage
-const atom = create(getLocalStorage('foo') || initialState)
+const atom = atom(getLocalStorage('foo') || initialState)
 atom.subscribe(setLocalStorage('foo'))
 ```

--- a/docs/recipes/redux-devtools-integration.md
+++ b/docs/recipes/redux-devtools-integration.md
@@ -7,16 +7,16 @@ Import `@xoid/devtools` and set a `debugValue` to your atom. It will send values
 
 ```js
 import { devtools } from '@xoid/devtools'
-import { create, use } from 'xoid'
+import { atom, use } from 'xoid'
 devtools() // run once
 
-const atom = create(
+const $atom = create(
   { alpha: 5 }, 
-  (atom) => {
-    const $alpha = atom.focus(s => s.alpha)
+  (a) => {
+    const $alpha = a.focus(s => s.alpha)
     return {
       inc: () => $alpha.update(s => s + 1),
-      resetState: () => atom.set({ alpha: 5 })
+      resetState: () => a.set({ alpha: 5 })
       deeply: {
         nested: {
           action: () => $alpha.set(5)
@@ -26,10 +26,10 @@ const atom = create(
   }
 )
 
-atom.debugValue = 'myAtom' // enable watching it by the devtools
+$atom.debugValue = '$atom' // enable watching it by the devtools
 
-const { deeply, incrementAlpha } = atom.actions // destructuring is no problem
-incrementAlpha() // logs "(myAtom).incrementAlpha"
-deeply.nested.action() // logs "(myAtom).deeply.nested.action"
-atom.focus(s => s.alpha).set(25)  // logs "(myAtom) Update ([timestamp])
+const { deeply, incrementAlpha } = $atom.actions // destructuring is no problem
+incrementAlpha() // logs "($atom).incrementAlpha"
+deeply.nested.action() // logs "($atom).deeply.nested.action"
+$atom.focus(s => s.alpha).set(25)  // logs "($atom) Update ([timestamp])
 ```

--- a/docs/recipes/redux-devtools-integration.md
+++ b/docs/recipes/redux-devtools-integration.md
@@ -10,7 +10,7 @@ import { devtools } from '@xoid/devtools'
 import { atom, use } from 'xoid'
 devtools() // run once
 
-const $atom = create(
+const $atom = atom(
   { alpha: 5 }, 
   (a) => {
     const $alpha = a.focus(s => s.alpha)

--- a/docs/recipes/redux-interop.md
+++ b/docs/recipes/redux-interop.md
@@ -27,7 +27,7 @@ const $mediatorAtom = atom((read) => read(store.getState, store.subscribe))
 $mediatorAtom.set = (payload) => store.dispatch({ type: 'EXTERNAL_XOID_UPDATE', payload })
 ```
 
-> Usually, atoms are derived from other **atoms** (as `create((read) => get($someAtom))`). Observe how `read` is used with two arguments in this example. This is an additional overload that is used to consume an external (non-**xoid**) source. As long as the external source implements some getState & subscribe pair, it can be consumed by **xoid** like this. (See [Deriving state from external sources](../advanced-concepts#deriving-state-from-external-sources))
+> Usually, atoms are derived from other **atoms** (as `atom((read) => get($someAtom))`). Observe how `read` is used with two arguments in this example. This is an additional overload that is used to consume an external (non-**xoid**) source. As long as the external source implements some getState & subscribe pair, it can be consumed by **xoid** like this. (See [Deriving state from external sources](../advanced-concepts#deriving-state-from-external-sources))
 >
 > Also, in the second line, you may see that the default `set` method is overriden. In **xoid**'s terminology, atoms like these are called [enhanced atoms](../advanced-concepts#enhanced-atoms). Overriding the default `set` method also will modify the `update` method's behavior.
 

--- a/docs/recipes/redux-interop.md
+++ b/docs/recipes/redux-interop.md
@@ -23,7 +23,7 @@ This will forward subscriptions and state modifications directly to the Redux st
 ```js
 import { store } from './store'
 
-const $mediatorAtom = create((read) => read(store.getState, store.subscribe))
+const $mediatorAtom = atom((read) => read(store.getState, store.subscribe))
 $mediatorAtom.set = (payload) => store.dispatch({ type: 'EXTERNAL_XOID_UPDATE', payload })
 ```
 

--- a/docs/recipes/using-immer.md
+++ b/docs/recipes/using-immer.md
@@ -3,15 +3,15 @@ id: using-immer
 title: Using immer
 ---
 
-While **xoid**'s API surface is kept small intentionally, there's a way for extensions. 
+`atom` has a `.plugins` array that you can use to enable plugins globally.
 If you'd like to add a `.produce` method that uses **immer** internally, you can do it like the following.
 
 ```js
-import { create } from 'xoid'
+import { atom } from 'xoid'
 import { produce } from 'immer'
 
-create.plugins.push((atom) => {
-  atom.produce = (fn) => atom.update((s) => produce(s, fn))
+atom.plugins.push((a) => {
+  a.produce = (fn) => a.update((s) => produce(s, fn))
 })
 ```
 

--- a/docs/recipes/using-reducers.md
+++ b/docs/recipes/using-reducers.md
@@ -44,8 +44,8 @@ dispatch({ type: types.increase, by: 1 })
 Connecting existing reducers to **xoid** can be beneficial, especially if you're planning to gradually refactor your reducers. The above reducer can be simplified into to the following:
 
 ```js
-const CounterModel = (state) => create(state, (atom) => {
-  const $count = atom.focus('count')
+const CounterModel = (state) => create(state, (a) => {
+  const $count = a.focus('count')
   return {
     increment: (by) => $count.update(s => s + by),
     decrement: (by) => $count.update(s => s - by),

--- a/docs/recipes/using-reducers.md
+++ b/docs/recipes/using-reducers.md
@@ -3,16 +3,13 @@ id: using-reducers
 title: Using reducers
 ---
 
-**xoid** doesn't need reducers, but if you prefer to use them, or if you're moving away from Redux, but want to reuse your existing reducers, you can easily do that with **xoid**. 
-
-The following function can be used to create a Redux-like atom.
+You can easily use your existing reducers with **xoid**. The following function can be used to create an atom with reducer.
 
 ```js
-const createStore = (reducer, state) => {
-  const atom = create(state)
-  const dispatch = (action) => atom.update((s) => reducer(s, action))
-  return { atom, dispatch }
-}
+const atomWithReducer = (reducer, initialState) => atom(
+  initialState, 
+  (a) => ({ dispatch: (action) => a.update((s) => reducer(s, action)) })
+)
 ```
 Let's take this simple reducer:
 
@@ -36,15 +33,15 @@ const counterReducer = (state, { type, by }) => {
 Usage:
 
 ```js
-const { atom, dispatch } = createStore({ count: 0 }, counterReducer)
+const countAtom = atomWithReducer({ count: 0 }, counterReducer)
 
-dispatch({ type: types.increase, by: 1 })
+countAtom.actions.dispatch({ type: types.increase, by: 1 })
 ```
 
 Connecting existing reducers to **xoid** can be beneficial, especially if you're planning to gradually refactor your reducers. The above reducer can be simplified into to the following:
 
 ```js
-const CounterModel = (state) => create(state, (a) => {
+const CounterModel = (s) => create(s, (a) => {
   const $count = a.focus('count')
   return {
     increment: (by) => $count.update(s => s + by),

--- a/docs/recipes/using-reducers.md
+++ b/docs/recipes/using-reducers.md
@@ -41,7 +41,7 @@ countAtom.actions.dispatch({ type: types.increase, by: 1 })
 Connecting existing reducers to **xoid** can be beneficial, especially if you're planning to gradually refactor your reducers. The above reducer can be simplified into to the following:
 
 ```js
-const CounterModel = (s) => create(s, (a) => {
+const CounterModel = (s) => atom(s, (a) => {
   const $count = a.focus('count')
   return {
     increment: (by) => $count.update(s => s + by),

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -14,14 +14,14 @@ Streams differ from atoms not only by types, but also in terms of the runtime be
 
 There are two ways to produce a stream in **xoid**:
 - Using the `.map` method with `true` as the second argument 
-- Using `create` with no arguments
+- Using `atom` with no arguments
 
 ### Using the `.map` method with `true` as the second argument 
 
 Imagine we're setting up a basic counter, and we're deriving another counter that takes only the odd values from the first.
 We can set this up in the following way:
 ```js
-const $counter = create(0)
+const $counter = atom(0)
 const $odd = $counter.map((s) => s % 2 ? s : undefined, true) 
 // Type of `$odd` would be `Stream<number>`
 ```
@@ -34,15 +34,15 @@ const $doubleOdd = $odd.map((value) => value * 2)
 ```
 Here, the type of `value` is always a `number`. If we were working with a `Atom<number | undefined>` instead of a `Stream<number>`, `value` would also be `number | undefined` and our code would be slightly more verbose to cover those cases.
 
-### Using `create` with no arguments
+### Using `atom` with no arguments
 
-When no arguments are used, `create` function produces a `Stream` instead of an `Atom`. Let's assume we're creating a `$clickStream` and a `$clickAtom` like the following:
+When no arguments are used, `atom` function produces a `Stream` instead of an `Atom`. Let's assume we're creating a `$clickStream` and a `$clickAtom` like the following:
 
 ```js
-import create from 'xoid'
+import { atom } from 'xoid'
 
-const $clickStream = create<MouseEvent>() // Stream<MouseEvent>
-const $clickAtom = create<MouseEvent | undefined>(undefined) // Atom<MouseEvent | undefined>
+const $clickStream = atom<MouseEvent>() // Stream<MouseEvent>
+const $clickAtom = atom<MouseEvent | undefined>(undefined) // Atom<MouseEvent | undefined>
 
 // Imagine we're going to satisfy the internal value of these atoms later as:
 window.addEventListener('click', $clickStream.set)

--- a/examples/celcius-fahrenheit/package.json
+++ b/examples/celcius-fahrenheit/package.json
@@ -8,8 +8,8 @@
     "react": "17.0.0",
     "react-dom": "17.0.0",
     "react-scripts": "3.4.3",
-    "xoid": "^1.0.0-beta.11",
-    "@xoid/react": "^1.0.0-beta.11"
+    "xoid": "^1.0.0-beta.12",
+    "@xoid/react": "^1.0.0-beta.12"
   },
   "devDependencies": {
     "typescript": "3.8.3"

--- a/examples/celcius-fahrenheit/src/App.tsx
+++ b/examples/celcius-fahrenheit/src/App.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { create } from 'xoid'
+import { atom } from 'xoid'
 import { useAtom } from '@xoid/react'
 
-const $celcius = create(20)
-const $fahrenheit = create(68)
+const $celcius = atom(20)
+const $fahrenheit = atom(68)
 
 const setC = (num: number) => {
   if (!num) num = 0

--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -8,8 +8,8 @@
     "react": "17.0.0",
     "react-dom": "17.0.0",
     "react-scripts": "3.4.3",
-    "xoid": "^1.0.0-beta.11",
-    "@xoid/react": "^1.0.0-beta.11"
+    "xoid": "^1.0.0-beta.12",
+    "@xoid/react": "^1.0.0-beta.12"
   },
   "devDependencies": {
     "typescript": "3.8.3"

--- a/examples/counter/src/App.tsx
+++ b/examples/counter/src/App.tsx
@@ -1,18 +1,18 @@
 import React from 'react'
-import { create } from 'xoid'
+import { atom } from 'xoid'
 import { useAtom } from '@xoid/react'
 import './styles.css'
 
 const NumberModel = (payload: number) =>
-  create(payload, (atom) => ({
-    increment: () => atom.update((state) => state + 1),
-    decrement: () => atom.update((state) => state - 1),
+  atom(payload, (a) => ({
+    increment: () => a.update((state) => state + 1),
+    decrement: () => a.update((state) => state - 1),
   }))
 type NumberType = ReturnType<typeof NumberModel>
 
 const $alpha = NumberModel(0)
 const $beta = NumberModel(5)
-const $sum = create((get) => get($alpha) + get($beta))
+const $sum = atom((get) => get($alpha) + get($beta))
 
 const NumberCounter = (props: { atom: NumberType; color: string }) => {
   const [value, { increment, decrement }] = useAtom(props.atom, true)

--- a/examples/dots-and-arrows/package.json
+++ b/examples/dots-and-arrows/package.json
@@ -12,8 +12,8 @@
     "react": "18.0.0",
     "react-dom": "18.0.0",
     "react-scripts": "4.0.3",
-    "xoid": "^1.0.0-beta.11",
-    "@xoid/react": "^1.0.0-beta.11"
+    "xoid": "^1.0.0-beta.12",
+    "@xoid/react": "^1.0.0-beta.12"
   },
   "devDependencies": {
     "@types/react": "17.0.20",

--- a/examples/dots-and-arrows/src/models.tsx
+++ b/examples/dots-and-arrows/src/models.tsx
@@ -1,26 +1,26 @@
-import { create } from 'xoid'
+import { atom } from 'xoid'
 
 export type DotType = { x: number; y: number }
 export type ArrowType = { from: string; to: string }
 export type BaseArrowType = { from: DotType; to: DotType }
 
 let isArrowPending = false
-export const $mousePositionDot = create(undefined as DotType | undefined)
+export const $mousePositionDot = atom(undefined as DotType | undefined)
 window.addEventListener('mousemove', (e) => {
   if (!isArrowPending) $mousePositionDot.set(undefined)
   $mousePositionDot.set({ x: e.clientX, y: e.clientY })
 })
 
 export const TemporaryArrowModel = (props: { onEndArrow: (value: ArrowType) => void }) =>
-  create(undefined as { from: string; to?: string } | undefined, (atom) => {
+  atom(undefined as { from: string; to?: string } | undefined, (a) => {
     const startArrow = (id: string) => {
       isArrowPending = true
-      atom.set({ from: id })
+      a.set({ from: id })
     }
     const endArrow = (id: string) => {
       isArrowPending = false
-      props.onEndArrow({ from: atom.value!.from, to: id })
-      atom.set(undefined)
+      props.onEndArrow({ from: a.value!.from, to: id })
+      a.set(undefined)
     }
 
     const startOrEndArrow = (id: string) => {
@@ -30,7 +30,7 @@ export const TemporaryArrowModel = (props: { onEndArrow: (value: ArrowType) => v
 
     const abortArrow = () => {
       isArrowPending = false
-      atom.set(undefined)
+      a.set(undefined)
     }
     window.addEventListener('keydown', abortArrow)
 

--- a/examples/finite-state-stopwatch/package.json
+++ b/examples/finite-state-stopwatch/package.json
@@ -8,8 +8,8 @@
     "react": "17.0.0",
     "react-dom": "17.0.0",
     "react-scripts": "3.4.3",
-    "xoid": "^1.0.0-beta.11",
-    "@xoid/react": "^1.0.0-beta.11"
+    "xoid": "^1.0.0-beta.12",
+    "@xoid/react": "^1.0.0-beta.12"
   },
   "devDependencies": {
     "typescript": "3.8.3"

--- a/examples/finite-state-stopwatch/src/App.tsx
+++ b/examples/finite-state-stopwatch/src/App.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import { create } from 'xoid'
+import { atom } from 'xoid'
 import { useSetup } from '@xoid/react'
 import { useAtom } from '@xoid/react'
 
 const TimerSetup = () => {
   let interval: ReturnType<typeof setTimeout>
-  const $time = create(0)
-  const $state = create(stopped)
+  const $time = atom(0)
+  const $state = atom(stopped)
 
   function stopped() {
     clearInterval(interval)

--- a/examples/redux-devtools-extension/package.json
+++ b/examples/redux-devtools-extension/package.json
@@ -6,11 +6,11 @@
   "main": "src/index.js",
   "dependencies": {
     "@xoid/devtools": "0.5.0",
-    "@xoid/react": "1.0.0-beta.11",
+    "@xoid/react": "1.0.0-beta.12",
     "react": "17.0.0",
     "react-dom": "17.0.0",
     "react-scripts": "3.4.3",
-    "xoid": "1.0.0-beta.11"
+    "xoid": "1.0.0-beta.12"
   },
   "devDependencies": {
     "typescript": "3.8.3"

--- a/examples/redux-devtools-extension/package.json
+++ b/examples/redux-devtools-extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xoid-counter-example",
+  "name": "xoid-redux-devtools-example",
   "version": "1.0.0",
   "description": "",
   "keywords": [],

--- a/examples/redux-devtools-extension/src/App.tsx
+++ b/examples/redux-devtools-extension/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { create } from 'xoid'
+import { atom } from 'xoid'
 import devtools from '@xoid/devtools'
 import { useAtom } from '@xoid/react'
 import './styles.css'
@@ -7,9 +7,9 @@ import './styles.css'
 devtools('my-app')
 
 const NumberModel = (payload: number) =>
-  create(payload, (atom) => ({
-    increment: () => atom.update((state) => state + 1),
-    decrement: () => atom.update((state) => state - 1),
+  atom(payload, (a) => ({
+    increment: () => a.update((state) => state + 1),
+    decrement: () => a.update((state) => state - 1),
   }))
 type NumberType = ReturnType<typeof NumberModel>
 
@@ -18,7 +18,7 @@ $alpha.debugValue = 'a'
 const $beta = NumberModel(16)
 $beta.debugValue = 'b'
 
-const $sum = create((get) => get($alpha) + get($beta))
+const $sum = atom((get) => get($alpha) + get($beta))
 
 const NumberCounter = (props: { atom: NumberType; color: string }) => {
   const [value, { increment, decrement }] = useAtom(props.atom, true)

--- a/examples/todos-basic/package.json
+++ b/examples/todos-basic/package.json
@@ -8,8 +8,8 @@
     "react": "17.0.0",
     "react-dom": "17.0.0",
     "react-scripts": "3.4.3",
-    "xoid": "^1.0.0-beta.11",
-    "@xoid/react": "^1.0.0-beta.11"
+    "xoid": "^1.0.0-beta.12",
+    "@xoid/react": "^1.0.0-beta.12"
   },
   "devDependencies": {
     "typescript": "3.8.3"

--- a/examples/todos-basic/src/App.tsx
+++ b/examples/todos-basic/src/App.tsx
@@ -1,19 +1,19 @@
 import React from 'react'
-import { create } from 'xoid'
+import { atom } from 'xoid'
 import { useAtom } from '@xoid/react'
 
 type TodoType = { title: string; checked: boolean }
 type TodoActions = { toggle: () => void; rename: (name: string) => void }
 
-const $todos = create(
+const $todos = atom(
   [
     { title: 'groceries', checked: true },
     { title: 'world invasion', checked: false },
   ],
-  (atom) => ({
-    add: (todo: TodoType) => atom.update((s) => [...s, todo]),
+  (a) => ({
+    add: (todo: TodoType) => a.update((s) => [...s, todo]),
     getItem: (index: number) => {
-      const $todo = atom.focus(index)
+      const $todo = a.focus(index)
       return {
         toggle: () => $todo.focus('checked').update((s) => !s),
         rename: $todo.focus('title').set,

--- a/examples/todos-filtered/package.json
+++ b/examples/todos-filtered/package.json
@@ -8,8 +8,8 @@
     "react": "17.0.0",
     "react-dom": "17.0.0",
     "react-scripts": "3.4.3",
-    "xoid": "^1.0.0-beta.11",
-    "@xoid/react": "^1.0.0-beta.11"
+    "xoid": "^1.0.0-beta.12",
+    "@xoid/react": "^1.0.0-beta.12"
   },
   "devDependencies": {
     "typescript": "3.8.3"

--- a/examples/todos-filtered/src/App.tsx
+++ b/examples/todos-filtered/src/App.tsx
@@ -1,19 +1,19 @@
 import React from 'react'
-import { create } from 'xoid'
+import { atom } from 'xoid'
 import { useAtom } from '@xoid/react'
 
 type TodoType = { title: string; checked: boolean }
 type TodoActions = { toggle: () => void; rename: (name: string) => void }
 
-const $todos = create(
+const $todos = atom(
   [
     { title: 'groceries', checked: true },
     { title: 'world invasion', checked: false },
   ],
-  (atom) => ({
-    add: (todo: TodoType) => atom.update((s) => [...s, todo]),
+  (a) => ({
+    add: (todo: TodoType) => a.update((s) => [...s, todo]),
     getItem: (index: number) => {
-      const $todo = atom.focus(index)
+      const $todo = a.focus(index)
       return {
         toggle: () => $todo.focus('checked').update((s) => !s),
         rename: $todo.focus('title').set,
@@ -22,9 +22,9 @@ const $todos = create(
   })
 )
 
-const $hideChecked = create(false)
+const $hideChecked = atom(false)
 
-const $filteredTodos = create((get) => {
+const $filteredTodos = atom((get) => {
   const hideChecked = get($hideChecked)
   const todos = get($todos)
   if (hideChecked) return todos.filter((item) => !item.checked)

--- a/examples/transient-update-resize-observer/package.json
+++ b/examples/transient-update-resize-observer/package.json
@@ -9,8 +9,8 @@
     "react-dom": "17.0.0",
     "react-scripts": "3.4.3",
     "@juggle/resize-observer": "^3.3.1",
-    "xoid": "^1.0.0-beta.11",
-    "@xoid/react": "^1.0.0-beta.11"
+    "xoid": "^1.0.0-beta.12",
+    "@xoid/react": "^1.0.0-beta.12"
   },
   "devDependencies": {
     "typescript": "3.8.3"

--- a/examples/use-items-abstraction/package.json
+++ b/examples/use-items-abstraction/package.json
@@ -8,8 +8,8 @@
     "react": "16.8.3",
     "react-dom": "16.8.3",
     "react-scripts": "2.1.8",
-    "xoid": "^1.0.0-beta.11",
-    "@xoid/react": "^1.0.0-beta.11"
+    "xoid": "^1.0.0-beta.12",
+    "@xoid/react": "^1.0.0-beta.12"
   },
   "devDependencies": {
     "typescript": "3.3.3"

--- a/examples/xoid-vs-usereducer-vs-usemethods/package.json
+++ b/examples/xoid-vs-usereducer-vs-usemethods/package.json
@@ -9,8 +9,8 @@
     "react-dom": "16.8.3",
     "react-scripts": "2.1.8",
     "use-methods": "0.4.5",
-    "xoid": "^1.0.0-beta.11",
-    "@xoid/react": "^1.0.0-beta.11"
+    "xoid": "^1.0.0-beta.12",
+    "@xoid/react": "^1.0.0-beta.12"
   },
   "devDependencies": {
     "typescript": "3.3.3"

--- a/examples/xoid-vs-usereducer-vs-usemethods/src/XoidCounters.js
+++ b/examples/xoid-vs-usereducer-vs-usemethods/src/XoidCounters.js
@@ -1,12 +1,12 @@
 import React from "react";
-import { create, use } from "xoid";
+import { atom } from "xoid";
 import { useAtom, useSetup } from '@xoid/react'
 import Counter from "./Counter";
 
 export default function XoidCounters() {
-  const atom = useSetup(() => CountersModel(initialState));
-  const counters = useAtom(atom);
-  const { addCounter, incrementCounter, resetCounter } = atom.actions;
+  const $atom = useSetup(() => CountersModel(initialState));
+  const counters = useAtom($atom);
+  const { addCounter, incrementCounter, resetCounter } = $atom.actions;
 
   return (
     <>
@@ -30,18 +30,18 @@ const initialState = {
 };
 
 const CountersModel = ({ counters, nextId }) =>
-  create(counters, (atom) => {
-    const getCount = (id) => {
-      const index = atom.value.findIndex((counter) => counter.id === id);
-      return atom.focus((s) => s[index].count);
+  atom(counters, (a) => {
+    const getCountAtomById = (id) => {
+      const index = a.value.findIndex((counter) => counter.id === id);
+      return a.focus((s) => s[index].count);
     };
 
     return {
       addCounter: () => {
-        atom.focus((s) => s[nextId]).set({ id: nextId, count: 0 });
+        a.focus((s) => s[nextId]).set({ id: nextId, count: 0 });
         nextId++;
       },
-      incrementCounter: (id) => getCount(id).update((s) => s + 1),
-      resetCounter: (id) => getCount(id).set(0)
+      incrementCounter: (id) => getCountAtomById(id).update((s) => s + 1),
+      resetCounter: (id) => getCountAtomById(id).set(0)
     };
   });

--- a/packages/deprecated/lite/package.json
+++ b/packages/deprecated/lite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xoid/lite",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "main": "./index.js",
   "module": "./index.esm.js",
   "types": "./index.d.ts",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xoid/devtools",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "main": "./index.js",
   "types": "./index.d.ts",
   "exports": {

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -33,6 +33,6 @@
     "observable"
   ],
   "peerDependencies": {
-    "xoid": ">=1.0.0-beta.11"
+    "xoid": ">=1.0.0-beta.12"
   }
 }

--- a/packages/devtools/src/devtools.tsx
+++ b/packages/devtools/src/devtools.tsx
@@ -40,11 +40,10 @@ const devtools = (instanceName = 'xoid') => {
     })
   })
 
-  internal.send = (atom: Atom) => {
-    const internal = atom[INTERNAL]
+  internal.send = (internal: any) => {
     const debugValue = internal.debugValue
     if (debugValue) {
-      const id = atomMap[debugValue].map.get(atom)
+      const id = atomMap[debugValue].map.get(internal)
       const regKey = id ? `${debugValue}-${id}` : debugValue
       $registry.focus((s) => s[regKey]).set(internal.get())
     }

--- a/packages/incubator/atom-with-location/index.tsx
+++ b/packages/incubator/atom-with-location/index.tsx
@@ -1,0 +1,40 @@
+import { atom } from 'xoid'
+
+type Location = {
+  pathname?: string
+  searchParams?: URLSearchParams
+  hash?: string
+}
+
+const get = (): Location => {
+  if (typeof window === 'undefined' || !window.location) {
+    return {}
+  }
+  return {
+    pathname: window.location.pathname,
+    searchParams: new URLSearchParams(window.location.search),
+    hash: window.location.hash,
+  }
+}
+
+const set = (location: Location): void => {
+  const url = new URL(window.location.href)
+  if ('pathname' in location) url.pathname = location.pathname!
+  if ('searchParams' in location) url.search = location.searchParams!.toString()
+  if ('hash' in location) url.hash = location.hash!
+  window.history.pushState(null, '', url)
+}
+
+const subscribe = (callback: () => void) => {
+  window.addEventListener('popstate', callback)
+  return () => window.removeEventListener('popstate', callback)
+}
+
+type Options<T> = {
+  get?: () => T
+  set?: (location: T, options?: { replace?: boolean }) => void
+  subscribe?: (callback: () => void) => () => void
+}
+
+export const atomWithLocation = (options: Options<Location> = { get, set, subscribe }) =>
+  atom.call(options)

--- a/packages/incubator/dnd/index.tsx
+++ b/packages/incubator/dnd/index.tsx
@@ -1,0 +1,34 @@
+import { atom, effect, inject, feature, setup } from 'xoid'
+
+const $startFeature = feature(() => atom(['pointerdown']))
+const $endFeature = feature(() => atom(['pointerup']))
+const $moveFeature = feature(() => atom(['pointermove']))
+
+const $isDraggingFeature = feature(() => {
+  const [$start, $end, $move] = [$startFeature, $endFeature, $moveFeature].map(inject)
+  const $isDragging = atom(false)
+  let to
+
+  effect(() => {
+    $start.subscribe((e) => {
+      to = setTimeout(() => {
+        $isDragging.value = true
+        to = null
+      }, 400)
+    })
+
+    $end.subscribe(() => {
+      $isDragging.value = false
+      clearTimeout(to)
+    })
+
+    $move.subscribe(fn)
+  })
+
+  return $isDragging
+})
+
+const dispose = setup(() => {
+  const $isDragging = inject($isDraggingFeature)
+  return {}
+})

--- a/packages/incubator/plugins-draft/plugins.ts
+++ b/packages/incubator/plugins-draft/plugins.ts
@@ -1,0 +1,112 @@
+// an atom that can
+type Action = any
+type Reducer<T> = (state: T, action: Action) => T
+
+const pluginReducer = <T>(options: { reducer?: Reducer<T> }) => {
+  const { reducer } = options
+  return {
+    dispatch(action: Action) {
+      this.update((s) => reducer(s, action))
+    },
+  }
+}
+
+const pluginProduce = <T>(options: {}) => {
+  return {
+    produce(fn: (draft: T) => void) {
+      this.update((s) => produce(s, fn))
+    },
+  }
+}
+
+const pluginLocalStorage = (atom: any, options: { localStorageKey?: string }) => {
+  const { localStorageKey } = options
+  if (!localStorageKey) return
+
+  const get = (init) => {
+    const maybeItem = localStorage.getItem(localStorageKey)
+    if (maybeItem) return JSON.parse(maybeItem)
+    return init
+  }
+  const set = (state) => localStorage.setItem(localStorageKey, JSON.stringify(state))
+  atom.middleware({ get, set })
+}
+
+type ReduxLikeStore<T> = {
+  getState: () => T
+  dispatch: (action: any) => void
+  subscribe: () => () => void
+}
+
+const pluginRedux = (options: { reduxStore: ReduxLikeStore<unknown>; reduxActionType: string }) => {
+  const { reduxStore, reduxActionType } = options
+  if (!reduxStore) return
+
+  atom.middleware({
+    get: reduxStore.getState,
+    set: (s) => reduxStore.dispatch({ type: reduxActionType, payload: s }),
+    subscribe: reduxStore.subscribe,
+  })
+}
+
+export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I
+) => void
+  ? I
+  : never
+
+type Composable = (context: any, options?: any) => any
+type GetOptions<T> = T extends (a: any, b: infer P) => any ? P : {}
+type GetExtensions<T> = T extends (a: any, b: any) => infer P ? P : never
+
+export type Truthy<T> = Exclude<T, false | 0 | '' | null | undefined>
+
+const create = <T, P extends Composable>(i, plugins: P[]) => {
+  type Options = UnionToIntersection<GetOptions<P>>
+  type Extensions = UnionToIntersection<GetExtensions<P>>
+  return <T>(init: T, options?: Options) => {
+    const atom = create(init, options)
+    plugins.forEach((fn) => fn(atom, options))
+    return atom as Extensions
+  }
+}
+
+const createWithReducer = <T>(value: T) => create(value, [pluginProduce<T>, pluginReducer])
+
+declare const bind: <T, P>(options: {
+  plugins: (type?: T) => P[]
+}) => (value: T) => GetExtensions<P>
+
+const atomWithReducer = bind({
+  plugins: <T>() => [pluginProduce<T>, pluginReducer],
+})
+
+const a = atomWithReducer({ anan: 4 })
+
+const newCreate = middleware({
+  plugins: (value) => [pluginProduce<typeof value>, pluginReducer],
+})
+//
+
+// TODO: This is nice, but doesn't tell anything in terms of options in the second argument.
+// To truly build a plugin system, we need that too.
+const extend = <T, P>(object: T, plugins: P[]) => {
+  for (const item of plugins) {
+    const descriptors = Object.getOwnPropertyDescriptors(item)
+    Object.defineProperties(object, descriptors)
+  }
+  return object as T & P
+}
+
+// Attempt to have options
+// It cannot be purely merge/assign based!
+const extend2 =
+  <T, O, P extends (options: any) => any>(plugins: P[], createObject: (options: O) => T) =>
+  (options: Parameters<O>[0]) => {
+    const object = createObject(options)
+    for (const item of plugins) {
+      const descriptors = Object.getOwnPropertyDescriptors(item(options))
+      Object.defineProperties(object, descriptors)
+    }
+    return object as T & ReturnType<P>
+  }

--- a/packages/incubator/produce/package.json
+++ b/packages/incubator/produce/package.json
@@ -2,7 +2,7 @@
   "name": "@xoid/produce",
   "version": "0.0.1",
   "main": "./index.js",
-  "module": "./index.esm.js",
+  "module": "./esm/index.js",
   "types": "./index.d.ts",
   "sideEffects": false,
   "description": "Framework-agnostic state management library designed for simplicity and scalability",

--- a/packages/incubator/produce/package.json
+++ b/packages/incubator/produce/package.json
@@ -29,6 +29,6 @@
     "observable"
   ],
   "peerDependencies": {
-    "xoid": ">=1.0.0-beta.11"
+    "xoid": ">=1.0.0-beta.12"
   }
 }

--- a/packages/incubator/react-extras/package.json
+++ b/packages/incubator/react-extras/package.json
@@ -2,7 +2,7 @@
   "name": "@xoid/react-extras",
   "version": "0.0.1",
   "main": "./index.js",
-  "module": "./index.esm.js",
+  "module": "./esm/index.js",
   "types": "./index.d.ts",
   "sideEffects": false,
   "description": "Framework-agnostic state management library designed for simplicity and scalability",

--- a/packages/incubator/resize-observer/index.tsx
+++ b/packages/incubator/resize-observer/index.tsx
@@ -1,0 +1,25 @@
+const resizeObserverFeature = feature(() => {
+  const $resizeObserverEntry = atom<ResizeObserverEntry>()
+  const resizeObserver = new ResizeObserver((entries) => {
+    for (const entry of entries) $resizeObserverEntry.set(entry)
+  })
+  return { resizeObserver, $resizeObserverEntry }
+})
+
+const ResizeObserverModel = (element) => {
+  const { resizeObserver, $resizeObserverEntry } = inject(resizeObserverFeature)
+  return atom.call({
+    subscribe(listener) {
+      resizeObserver.observe(element)
+      const dispose = $resizeObserverEntry.subscribe((entry) => {
+        if (entry.target === element) listener(entry)
+      })
+      return () => {
+        resizeObserver.unobserve(element)
+        dispose()
+      }
+    },
+  })
+}
+
+ResizeObserverModel(myDiv).subscribe(() => {})

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xoid/react",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "main": "./index.js",
   "module": "./index.esm.js",
   "types": "./index.d.ts",
@@ -54,7 +54,7 @@
     "use-sync-external-store": "^1.1.0"
   },
   "peerDependencies": {
-    "xoid": ">=1.0.0-beta.11",
+    "xoid": ">=1.0.0-beta.12",
     "react": "*"
   }
 }

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useDebugValue } from 'react'
-import { create, Atom } from 'xoid'
+import { atom, Atom } from 'xoid'
 import { useConstant } from './useConstant'
 import { useAdapter } from './useAdapter'
 
@@ -23,7 +23,7 @@ export function useSetup(fn: ($props?: any) => any, props?: any): any {
   /* eslint-disable react-hooks/rules-of-hooks */
   let result
   if (arguments.length > 1) {
-    const $props = useConstant(() => create(() => props))
+    const $props = useConstant(() => atom(() => props))
     useIsoLayoutEffect(() => ($props as Atom<any>).set(props), [props])
     result = useAdapter(() => fn($props))
   } else {

--- a/packages/react/src/useAdapter.tsx
+++ b/packages/react/src/useAdapter.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, createContext } from 'react'
-import { setup, InjectionKey, createAdapter } from 'xoid/setup'
+import { setup, InjectionKey, createAdapter } from 'xoid'
 import { useConstant } from './useConstant'
 
 const contextMap = new Map<InjectionKey<any>, React.Context<any>>()

--- a/packages/react/src/useAdapter.tsx
+++ b/packages/react/src/useAdapter.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, createContext } from 'react'
-import { setup, InjectionKey, createAdapter } from 'xoid'
+import type { InjectionKey } from 'xoid'
+import { setup, createAdapter } from 'xoid/setup'
 import { useConstant } from './useConstant'
 
 const contextMap = new Map<InjectionKey<any>, React.Context<any>>()

--- a/packages/reactive/README.md
+++ b/packages/reactive/README.md
@@ -54,10 +54,10 @@ data.count++
 **xoid** and **@xoid/reactive** libraries are interoperable. They export the same `create` function. The `.value` getter of an atom created by **xoid** package would also auto-subscribe when using `watch`, or `computed`
 
 ```js
-import { create } from 'xoid'
+import { atom } from 'xoid'
 import { computed } from '@xoid/reactive'
 
-const $count = create(0)
+const $count = atom(0)
 
 const $doubleCount = computed(() => data.count * 2)
 ```

--- a/packages/reactive/package.json
+++ b/packages/reactive/package.json
@@ -29,6 +29,6 @@
     "observable"
   ],
   "peerDependencies": {
-    "xoid": ">=1.0.0-beta.11"
+    "xoid": ">=1.0.0-beta.12"
   }
 }

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xoid/svelte",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "main": "./index.js",
   "module": "./index.esm.js",
   "types": "./index.d.ts",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -47,7 +47,7 @@
     "observable"
   ],
   "peerDependencies": {
-    "xoid": ">=1.0.0-beta.11",
+    "xoid": ">=1.0.0-beta.12",
     "svelte": "*"
   }
 }

--- a/packages/svelte/src/index.tsx
+++ b/packages/svelte/src/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-import { create, Atom } from 'xoid'
+import { atom, Atom } from 'xoid'
 import { onDestroy } from 'svelte'
 import type { Readable } from 'svelte/store'
 import { useAdapter } from './useAdapter'
@@ -13,7 +13,7 @@ export function useSetup<T>(fn: () => T): T
 export function useSetup<T, P>(fn: ($props: Atom<P>) => T, props: Readable<P>): T
 export function useSetup(fn: ($props?: any) => any, props?: Readable<any>): any {
   if (arguments.length > 1) {
-    const $props = create(() => props)
+    const $props = atom(() => props)
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     onDestroy(props!.subscribe((value) => $props.set(value)))
     return useAdapter(() => fn($props))

--- a/packages/svelte/src/useAdapter.tsx
+++ b/packages/svelte/src/useAdapter.tsx
@@ -1,4 +1,4 @@
-import { setup, createAdapter } from 'xoid'
+import { setup, createAdapter } from 'xoid/setup'
 import { getContext, onDestroy, onMount } from 'svelte'
 
 export const useAdapter = <T,>(fn: () => T): T => {

--- a/packages/svelte/src/useAdapter.tsx
+++ b/packages/svelte/src/useAdapter.tsx
@@ -1,4 +1,4 @@
-import { setup, createAdapter } from 'xoid/setup'
+import { setup, createAdapter } from 'xoid'
 import { getContext, onDestroy, onMount } from 'svelte'
 
 export const useAdapter = <T,>(fn: () => T): T => {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xoid/vue",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "./index.js",
   "module": "./index.esm.js",
   "types": "./index.d.ts",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -47,7 +47,7 @@
     "observable"
   ],
   "peerDependencies": {
-    "xoid": ">=1.0.0-beta.11",
+    "xoid": ">=1.0.0-beta.12",
     "vue": "<=3.1"
   }
 }

--- a/packages/vue/src/index.tsx
+++ b/packages/vue/src/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { provide, watch, onUnmounted, renderSlot, defineComponent } from 'vue'
-import { create, Atom } from 'xoid'
+import { atom, Atom } from 'xoid'
 import { useAdapter } from './useAdapter'
 import { InjectionKey } from 'xoid'
 export { useAtom } from './useAtom'
@@ -22,7 +22,7 @@ export function useSetup<T>(fn: () => T): T
 export function useSetup<T, P>(fn: ($props: Atom<P>) => T, props: P): T
 export function useSetup(fn: ($props?: any) => any, props?: any): any {
   if (arguments.length > 1) {
-    const $props = create(() => props)
+    const $props = atom(() => props)
     onUnmounted(watch(props, () => $props.set({ ...props })))
     return useAdapter(() => fn($props))
   }

--- a/packages/vue/src/index.tsx
+++ b/packages/vue/src/index.tsx
@@ -2,7 +2,7 @@
 import { provide, watch, onUnmounted, renderSlot, defineComponent } from 'vue'
 import { create, Atom } from 'xoid'
 import { useAdapter } from './useAdapter'
-import { InjectionKey } from 'xoid/setup'
+import { InjectionKey } from 'xoid'
 export { useAtom } from './useAtom'
 
 export const createProvider = <T,>(key: InjectionKey<T>, defaultValue: T) => {

--- a/packages/vue/src/useAdapter.tsx
+++ b/packages/vue/src/useAdapter.tsx
@@ -1,5 +1,5 @@
 import { inject, onMounted, onUnmounted } from 'vue'
-import { setup, createAdapter } from 'xoid'
+import { setup, createAdapter } from 'xoid/setup'
 
 export const useAdapter = <T,>(fn: () => T): T => {
   const adapter = createAdapter({ inject })

--- a/packages/vue/src/useAdapter.tsx
+++ b/packages/vue/src/useAdapter.tsx
@@ -1,5 +1,5 @@
 import { inject, onMounted, onUnmounted } from 'vue'
-import { setup, createAdapter } from 'xoid/setup'
+import { setup, createAdapter } from 'xoid'
 
 export const useAdapter = <T,>(fn: () => T): T => {
   const adapter = createAdapter({ inject })

--- a/packages/xoid/package.json
+++ b/packages/xoid/package.json
@@ -4,6 +4,18 @@
   "main": "./index.js",
   "module": "./index.esm.js",
   "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "module": "./index.esm.js",
+      "default": "./index.js"
+    },
+    "./setup": {
+      "types": "./setup.d.ts",
+      "module": "./setup.esm.js",
+      "default": "./setup.js"
+    }
+  },
   "sideEffects": false,
   "description": "Framework-agnostic state management library designed for simplicity and scalability",
   "author": "onurkerimov",

--- a/packages/xoid/package.json
+++ b/packages/xoid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xoid",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "main": "./index.js",
   "module": "./index.esm.js",
   "types": "./index.d.ts",

--- a/packages/xoid/package.json
+++ b/packages/xoid/package.json
@@ -4,18 +4,6 @@
   "main": "./index.js",
   "module": "./index.esm.js",
   "types": "./index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./index.d.ts",
-      "module": "./index.esm.js",
-      "default": "./index.js"
-    },
-    "./setup": {
-      "types": "./setup.d.ts",
-      "module": "./setup.esm.js",
-      "default": "./setup.js"
-    }
-  },
   "sideEffects": false,
   "description": "Framework-agnostic state management library designed for simplicity and scalability",
   "author": "onurkerimov",

--- a/packages/xoid/src/atom.tsx
+++ b/packages/xoid/src/atom.tsx
@@ -1,0 +1,28 @@
+import type { Atom, Stream, Init, GetState, Actions } from './internal/types'
+import { createAtom, createInternal, tools } from './internal/utils'
+import { createSelector } from './internal/createSelector'
+
+/**
+ * Creates an atom with the first argument as the initial state.
+ * Second argument can be used to attach actions to the atom.
+ * @see [xoid.dev/docs/quick-tutorial](https://xoid.dev/docs/quick-tutorial)
+ */
+export function atom<T>(): Stream<T>
+export function atom<T>(init: Init<T>): Atom<T>
+export function atom<T, U>(init: Init<T>, getActions?: (atom: Atom<T>) => U): Atom<T> & Actions<U>
+export function atom<T, U = undefined>(init?: Init<T>, getActions?: (atom: Atom<T>) => U) {
+  const isFunction = typeof init === 'function'
+  const internal = createInternal(
+    (isFunction ? undefined : init) as T,
+    (() => tools.send(a)) as any
+  )
+  internal.isStream = !arguments.length
+  if (isFunction) createSelector(internal, init as (get: GetState) => T)
+  const a = createAtom(internal, getActions)
+  return a
+}
+
+atom.plugins = [] as ((atom: Atom<any>) => void)[]
+
+// intentionally untyped
+;(atom as any).internal = tools

--- a/packages/xoid/src/atom.tsx
+++ b/packages/xoid/src/atom.tsx
@@ -1,4 +1,4 @@
-import type { Atom, Stream, Init, GetState, Actions } from './internal/types'
+import type { Atom, Stream, Init, Actions } from './internal/types'
 import { createAtom, createInternal, tools } from './internal/utils'
 import { createSelector } from './internal/createSelector'
 
@@ -7,22 +7,20 @@ import { createSelector } from './internal/createSelector'
  * Second argument can be used to attach actions to the atom.
  * @see [xoid.dev/docs/quick-tutorial](https://xoid.dev/docs/quick-tutorial)
  */
-export function atom<T>(): Stream<T>
 export function atom<T>(init: Init<T>): Atom<T>
-export function atom<T, U>(init: Init<T>, getActions?: (atom: Atom<T>) => U): Atom<T> & Actions<U>
-export function atom<T, U = undefined>(init?: Init<T>, getActions?: (atom: Atom<T>) => U) {
-  const isFunction = typeof init === 'function'
-  const internal = createInternal(
-    (isFunction ? undefined : init) as T,
-    (() => tools.send(a)) as any
-  )
+export function atom<T, U>(init: Init<T>, getActions?: (a: Atom<T>) => U): Atom<T> & Actions<U>
+export function atom<T>(): Stream<T>
+export function atom<T, U = undefined>(init?: Init<T>, getActions?: (a: Atom<T>) => U) {
+  // @ts-ignore
+  const internal = (typeof init === 'function' ? createSelector : createInternal)(init)
+  // @ts-ignore
   internal.isStream = !arguments.length
-  if (isFunction) createSelector(internal, init as (get: GetState) => T)
-  const a = createAtom(internal, getActions)
-  return a
+
+  // @ts-ignore
+  return createAtom(internal, getActions)
 }
 
-atom.plugins = [] as ((atom: Atom<any>) => void)[]
+atom.plugins = [] as ((a: Atom<any>) => void)[]
 
 // intentionally untyped
 ;(atom as any).internal = tools

--- a/packages/xoid/src/index.tsx
+++ b/packages/xoid/src/index.tsx
@@ -1,10 +1,5 @@
 import { atom } from './atom'
-import {
-  inject as injectDeprecated,
-  effect as effectDeprecated,
-  createAdapter,
-  setup,
-} from './setup'
+import { inject as injectDeprecated, effect as effectDeprecated } from './setup'
 
 /**
  * @deprecated since version 1.0.0beta-12
@@ -29,7 +24,6 @@ export default create
 export { atom }
 export const inject = injectDeprecated
 export const effect = effectDeprecated
-export { createAdapter, setup }
 
 export type { InjectionKey, EffectCallback } from './setup'
 export * from './internal/types'

--- a/packages/xoid/src/index.tsx
+++ b/packages/xoid/src/index.tsx
@@ -1,32 +1,28 @@
-import type { Atom, Stream, Init, GetState, Actions } from './internal/types'
-import { createAtom, createInternal, tools } from './internal/utils'
-import { createSelector } from './internal/createSelector'
+import { atom } from './atom'
+import { inject as injectDeprecated, effect as effectDeprecated } from './setup'
 
 export * from './internal/types'
+export { atom }
 
 /**
- * Creates an atom with the first argument as the initial state.
- * Second argument can be used to attach actions to the atom.
- * @see [xoid.dev/docs/quick-tutorial](https://xoid.dev/docs/quick-tutorial)
+ * @deprecated since version 1.0.0beta-12
+ *
+ * `create` as a named export is deprecated. In the future versions, use this instead:
+ * @example
+ * // Recommended
+ * import { atom } from 'xoid'
  */
-export function create<T>(): Stream<T>
-export function create<T>(init: Init<T>): Atom<T>
-export function create<T, U>(init: Init<T>, getActions?: (atom: Atom<T>) => U): Atom<T> & Actions<U>
-export function create<T, U = undefined>(init?: Init<T>, getActions?: (atom: Atom<T>) => U) {
-  const isFunction = typeof init === 'function'
-  const internal = createInternal(
-    (isFunction ? undefined : init) as T,
-    (() => tools.send(atom)) as any
-  )
-  internal.isStream = !arguments.length
-  if (isFunction) createSelector(internal, init as (get: GetState) => T)
-  const atom = createAtom(internal, getActions)
-  return atom
-}
+export const create = atom
 
+/**
+ * @deprecated since version 1.0.0beta-12
+ *
+ * Default export is deprecated. In the future versions, use this instead:
+ * @example
+ * // Recommended
+ * import { atom } from 'xoid'
+ */
 export default create
 
-create.plugins = [] as ((atom: Atom<any>) => void)[]
-
-// intentionally untyped
-;(create as any).internal = tools
+export const inject = injectDeprecated
+export const effect = effectDeprecated

--- a/packages/xoid/src/index.tsx
+++ b/packages/xoid/src/index.tsx
@@ -1,8 +1,10 @@
 import { atom } from './atom'
-import { inject as injectDeprecated, effect as effectDeprecated } from './setup'
-
-export * from './internal/types'
-export { atom }
+import {
+  inject as injectDeprecated,
+  effect as effectDeprecated,
+  createAdapter,
+  setup,
+} from './setup'
 
 /**
  * @deprecated since version 1.0.0beta-12
@@ -24,5 +26,10 @@ export const create = atom
  */
 export default create
 
+export { atom }
 export const inject = injectDeprecated
 export const effect = effectDeprecated
+export { createAdapter, setup }
+
+export type { InjectionKey, EffectCallback } from './setup'
+export * from './internal/types'

--- a/packages/xoid/src/internal/createSelector.tsx
+++ b/packages/xoid/src/internal/createSelector.tsx
@@ -1,4 +1,4 @@
-import { Internal, tools } from './utils'
+import { createInternal, tools } from './utils'
 import { GetState } from './types'
 import { createEvent } from './createEvent'
 import { INTERNAL } from './createFocus'
@@ -16,7 +16,8 @@ export const createGetState =
     return read[INTERNAL].get()
   }
 
-export const createSelector = <T,>(internal: Internal<T>, init: (get: GetState) => T) => {
+export const createSelector = <T,>(init: (get: GetState) => T) => {
+  const internal = createInternal()
   const { get, set, listeners } = internal
   const e = createEvent()
 
@@ -41,4 +42,5 @@ export const createSelector = <T,>(internal: Internal<T>, init: (get: GetState) 
     if (isPending) evaluate()
     return get()
   }
+  return internal
 }

--- a/packages/xoid/src/internal/utils.tsx
+++ b/packages/xoid/src/internal/utils.tsx
@@ -54,15 +54,16 @@ export const subscribeInternal =
     }
   }
 
-export const createInternal = <T,>(value: T, send?: () => void): Internal<T> => {
+export const createInternal = <T,>(value?: T): Internal<T> => {
   const listeners = new Set<() => void>()
-  return {
+  const self = {
     listeners,
     get: () => value as T,
     set: (nextValue: T) => {
       if (value === nextValue) return
       value = nextValue
-      send && send()
+      // Used by devtools
+      tools.send(self)
       listeners.forEach((listener) => listener())
     },
     subscribe: (listener: () => void) => {
@@ -70,6 +71,7 @@ export const createInternal = <T,>(value: T, send?: () => void): Internal<T> => 
       return () => void listeners.delete(listener)
     },
   }
+  return self
 }
 
 export function createAtom<T>(internal: Internal<T>, getActions?: any) {

--- a/packages/xoid/src/setup.tsx
+++ b/packages/xoid/src/setup.tsx
@@ -18,8 +18,24 @@ let adapter = {
   inject: () => error('inject'),
 }
 
+/**
+ * @deprecated since version 1.0.0beta-12
+ *
+ * In the future versions, {@link inject} and {@link effect} will be exported from the root instead of the `xoid/setup` route.
+ * @example
+ * // Recommended
+ * import { inject } from 'xoid'
+ */
 export const inject = <T,>(symbol: InjectionKey<T>): T => (adapter.inject as any)(symbol)
 
+/**
+ * @deprecated since version 1.0.0beta-12
+ *
+ * In the future versions, {@link inject} and {@link effect} will be exported from the root instead of the `xoid/setup` route.
+ * @example
+ * // Recommended
+ * import { effect } from 'xoid'
+ */
 export const effect = (callback: EffectCallback): void => (adapter.effect as any)(callback)
 
 export function setup<T>(

--- a/tests/actions.test.tsx
+++ b/tests/actions.test.tsx
@@ -1,18 +1,18 @@
-import { create } from 'xoid'
+import { atom } from 'xoid'
 import { debug } from './testHelpers'
 
 it('uses the actions in vanilla (interop)', async () => {
-  const atom = create({ count: 0 }, (atom) => ({
-    inc: () => atom.update((state) => ({ count: state.count + 1 })),
+  const $atom = atom({ count: 0 }, (a) => ({
+    inc: () => a.update((state) => ({ count: state.count + 1 })),
   }))
-  atom.actions.inc()
-  expect(debug(atom)).toMatchSnapshot()
+  $atom.actions.inc()
+  expect(debug($atom)).toMatchSnapshot()
 })
 
 it('uses the actions in vanilla', async () => {
-  const atom = create({ count: 0 }, (atom) => ({
-    inc: () => atom.update((state) => ({ count: state.count + 1 })),
+  const $atom = atom({ count: 0 }, (a) => ({
+    inc: () => a.update((state) => ({ count: state.count + 1 })),
   }))
-  atom.actions.inc()
-  expect(debug(atom)).toMatchSnapshot()
+  $atom.actions.inc()
+  expect(debug($atom)).toMatchSnapshot()
 })

--- a/tests/isomorphism/CounterSetup.tsx
+++ b/tests/isomorphism/CounterSetup.tsx
@@ -1,5 +1,5 @@
 import { Atom } from 'xoid'
-import { effect } from 'xoid/setup'
+import { effect } from 'xoid'
 
 export const CounterSetup = ($props: Atom<{ initialValue: number }>) => {
   const $counter = $props.map((s) => s.initialValue)

--- a/tests/isomorphism/dependency-injection.test.tsx
+++ b/tests/isomorphism/dependency-injection.test.tsx
@@ -1,4 +1,4 @@
-import { inject, InjectionKey } from 'xoid/setup'
+import { inject, InjectionKey } from 'xoid'
 import { createProvider as createProviderReact, useSetup as useSetupReact } from '@xoid/react'
 import { createProvider as createProviderVue, useSetup as useSetupVue } from '@xoid/vue'
 import { render as renderReact } from '@testing-library/react'

--- a/tests/react.test.tsx
+++ b/tests/react.test.tsx
@@ -1,10 +1,8 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { act, cleanup, fireEvent, render } from '@testing-library/react'
-import { create } from 'xoid'
-import { effect } from 'xoid/setup'
-import { useSetup } from '@xoid/react'
-import { useAtom } from '@xoid/react'
+import { create, effect } from 'xoid'
+import { useAtom, useSetup } from '@xoid/react'
 import { debug } from './testHelpers'
 
 const consoleError = console.error

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declarationDir": "dist",
+    "skipLibCheck": true
+  },
+  "include": ["packages"],
+  "exclude": ["packages/deprecated", "packages/incubator"]
+}


### PR DESCRIPTION
This version, compared to the previous one only adds deprecation notices that can be fixed by slight modifications. Underlying implementations are not changed.

### Changed

- `create` (both as a named export and the default export) is marked as deprecated, and it has been renamed to `atom`. It will be removed in the further versions, and making the following change is recommended:
> Before:
> ```js
> import create from 'xoid'
>// or
> import { create } from 'xoid'
> ```
> After:
> ```js
> import { atom } from 'xoid'
> ```
- `inject` and `effect` exports are now exported from the root. They used to be exported from the `xoid/setup` route.

---

### Notes
- **Why is `create` being renamed?** Because we're planning to add exports such as `toAtom` and `toReactive` (They're currently in the `@xoid/reactive` module), and we aim naming consistency.

### Todo
- [x] Rename `create` imports to `atom` in the `docs/`
- [x] Rename `create` imports to `atom` in `examples/`
- [ ] Rename `create` imports to `atom` in `tests/`
- [x] Rename `create` imports in README.md
- [x] Rename `xoid/setup` imports to `xoid` in all docs
- [x] Remove `xoid/setup` from framework integration implementations
- [x] Bump package versions 